### PR TITLE
Adding a textScaleFactor property to the custom snack bar

### DIFF
--- a/lib/custom_snack_bar.dart
+++ b/lib/custom_snack_bar.dart
@@ -9,6 +9,7 @@ class CustomSnackBar extends StatefulWidget {
   final Color backgroundColor;
   final TextStyle textStyle;
   final int iconRotationAngle;
+  final double textScaleFactor;
 
   const CustomSnackBar.success({
     Key? key,
@@ -25,6 +26,7 @@ class CustomSnackBar extends StatefulWidget {
     ),
     this.iconRotationAngle = 32,
     this.backgroundColor = const Color(0xff00E676),
+    this.textScaleFactor = 1.0,
   });
 
   const CustomSnackBar.info({
@@ -42,6 +44,7 @@ class CustomSnackBar extends StatefulWidget {
     ),
     this.iconRotationAngle = 32,
     this.backgroundColor = const Color(0xff2196F3),
+    this.textScaleFactor = 1.0,
   });
 
   const CustomSnackBar.error({
@@ -59,6 +62,7 @@ class CustomSnackBar extends StatefulWidget {
     ),
     this.iconRotationAngle = 32,
     this.backgroundColor = const Color(0xffff5252),
+    this.textScaleFactor = 1.0,
   });
 
   @override
@@ -110,6 +114,7 @@ class _CustomSnackBarState extends State<CustomSnackBar> {
                 textAlign: TextAlign.center,
                 overflow: TextOverflow.ellipsis,
                 maxLines: 2,
+                textScaleFactor: widget.textScaleFactor,
               ),
             ),
           ),


### PR DESCRIPTION
Some accessibility solutions use the `textScaleFactor `property of the `Text()` widget in order to inflate/shrink text while maintaining its style. 
By exposing this property in `CustomSnackBar()` it can therefore become more accessible in those cases.