### PR TITLE
OverlayState should be nullable

### DIFF
--- a/lib/top_snack_bar.dart
+++ b/lib/top_snack_bar.dart
@@ -49,7 +49,7 @@ OverlayEntry? _previousEntry;
 /// can be dismissed. This argument is only used when [dismissType] is equal
 /// to `DismissType.onSwipe`. Defaults to `[DismissDirection.up]`
 void showTopSnackBar(
-  OverlayState overlayState,
+  OverlayState? overlayState,
   Widget child, {
   Duration animationDuration = const Duration(milliseconds: 1200),
   Duration reverseAnimationDuration = const Duration(milliseconds: 550),
@@ -93,7 +93,7 @@ void showTopSnackBar(
     _previousEntry?.remove();
   }
 
-  overlayState.insert(_overlayEntry);
+  overlayState?.insert(_overlayEntry);
   _previousEntry = _overlayEntry;
 }
 


### PR DESCRIPTION
When using sdk >= 2.12.0 `Overlay.of(context)` can return null.

You can check it by changing the sdk in the example.
```yaml
environment:
  sdk: ">=2.12.0 <3.0.0"
```

This PR makes `showTopSnackBar` accept a nullable `OverlayState` argument and handle the logic internally.
If it is `null` the TopSnackbar won't be displayed but there is no error nor exception