### PR TITLE
Refactor CustomSnackBar to allow customizing the height

### DIFF
--- a/lib/custom_snack_bar.dart
+++ b/lib/custom_snack_bar.dart
@@ -27,6 +27,7 @@ class CustomSnackBar extends StatefulWidget {
     this.borderRadius = kDefaultBorderRadius,
     this.textScaleFactor = 1.0,
     this.textAlign = TextAlign.center,
+    this.height = 80,
   }) : super(key: key);
 
   const CustomSnackBar.info({
@@ -52,6 +53,7 @@ class CustomSnackBar extends StatefulWidget {
     this.borderRadius = kDefaultBorderRadius,
     this.textScaleFactor = 1.0,
     this.textAlign = TextAlign.center,
+    this.height = 80,
   }) : super(key: key);
 
   const CustomSnackBar.error({
@@ -77,6 +79,7 @@ class CustomSnackBar extends StatefulWidget {
     this.borderRadius = kDefaultBorderRadius,
     this.textScaleFactor = 1.0,
     this.textAlign = TextAlign.center,
+    this.height = 80,
   }) : super(key: key);
 
   final String message;
@@ -92,6 +95,7 @@ class CustomSnackBar extends StatefulWidget {
   final EdgeInsetsGeometry messagePadding;
   final double textScaleFactor;
   final TextAlign textAlign;
+  final double height;
 
   @override
   CustomSnackBarState createState() => CustomSnackBarState();
@@ -103,7 +107,7 @@ class CustomSnackBarState extends State<CustomSnackBar> {
     final theme = Theme.of(context);
     return Container(
       clipBehavior: Clip.hardEdge,
-      height: 80,
+      height: widget.height,
       decoration: BoxDecoration(
         color: widget.backgroundColor,
         borderRadius: widget.borderRadius,


### PR DESCRIPTION
Currently, the CustomSnackBar has a fixed size, which limits the flexibility in displaying notifications. This update introduces the ability to customize the height of the popup by adding a new height parameter. With this improvement, developers can adjust the height of the CustomSnackBar as needed, making the user interface more adaptable to different use cases.