### PR TITLE
Fixes #63: add onTap behaviour when dismissType in onSwipe

### DIFF
--- a/lib/top_snack_bar.dart
+++ b/lib/top_snack_bar.dart
@@ -247,21 +247,29 @@ class _TopSnackBarState extends State<_TopSnackBar> with SingleTickerProviderSta
       case DismissType.onSwipe:
         var childWidget = widget.child;
         for (final direction in widget.dismissDirections) {
-          childWidget = Dismissible(
-            direction: direction,
-            key: UniqueKey(),
-            dismissThresholds: const {DismissDirection.up: 0.2},
-            confirmDismiss: (direction) async {
+          childWidget = TapBounceContainer(
+            onTap: () {
+              widget.onTap?.call();
               if (!widget.persistent && mounted) {
-                if (direction == DismissDirection.down) {
-                  await _animationController.reverse();
-                } else {
-                  _animationController.reset();
-                }
+                _animationController.reverse();
               }
-              return false;
             },
-            child: childWidget,
+            child: Dismissible(
+              direction: direction,
+              key: UniqueKey(),
+              dismissThresholds: const {DismissDirection.up: 0.2},
+              confirmDismiss: (direction) async {
+                if (!widget.persistent && mounted) {
+                  if (direction == DismissDirection.down) {
+                    await _animationController.reverse();
+                  } else {
+                    _animationController.reset();
+                  }
+                }
+                return false;
+              },
+              child: childWidget,
+            ),
           );
         }
         return childWidget;


### PR DESCRIPTION
This fix ensures that the onTap callback is respected even when the dismissType is set to DismissType.onSwipe. The implementation prioritizes the onTap action when a tap is detected, while still allowing the swipe gesture for dismissal. Now, both interactions—tapping and swiping—work as expected without conflict.

Changes:
Updated the SnackBar behavior to properly detect taps and trigger the onTap callback when DismissType.onSwipe is enabled.